### PR TITLE
feat: add deployment script and workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run export
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - run: ./scripts/deploy.sh
+        env:
+          S3_BUCKET: ${{ secrets.S3_BUCKET }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+          INVALIDATION_PATHS: ${{ secrets.INVALIDATION_PATHS }}

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,16 @@
+# Deployment
+
+## Required GitHub Secrets
+
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `AWS_REGION`
+- `S3_BUCKET`
+- `CLOUDFRONT_DISTRIBUTION_ID`
+- (optional) `INVALIDATION_PATHS`
+
+## Manual run
+
+```bash
+S3_BUCKET=my-bucket AWS_REGION=us-east-1 CLOUDFRONT_DISTRIBUTION_ID=XYZ ./scripts/deploy.sh
+```

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Required environment variables
+: "${S3_BUCKET:?S3_BUCKET is required}"
+: "${AWS_REGION:?AWS_REGION is required}"
+: "${CLOUDFRONT_DISTRIBUTION_ID:?CLOUDFRONT_DISTRIBUTION_ID is required}"
+
+BUILD_DIR="${BUILD_DIR:-out}"
+INVALIDATION_PATHS="${INVALIDATION_PATHS:-"/*"}"
+
+echo "Deploying '$BUILD_DIR' to s3://$S3_BUCKET in region $AWS_REGION"
+
+# Sync versioned assets first with long cache lifetime
+aws s3 sync "$BUILD_DIR/_next" "s3://$S3_BUCKET/_next" \
+  --cache-control "public, max-age=31536000, immutable" \
+  --delete
+
+# Sync remaining assets with no-cache headers
+aws s3 sync "$BUILD_DIR" "s3://$S3_BUCKET" \
+  --exclude "_next/*" \
+  --cache-control "no-cache, no-store, must-revalidate" \
+  --delete
+
+# Invalidate CloudFront cache
+aws cloudfront create-invalidation \
+  --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" \
+  --paths "$INVALIDATION_PATHS"
+
+echo "Deployment complete"


### PR DESCRIPTION
## Summary
- add S3/CloudFront deploy script with cache-control handling and invalidation
- configure GitHub Actions workflow for static export deploys
- document required secrets and manual deployment steps

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68bb76b8b0e08333bc92a6730f7436cf