### PR TITLE
feat: use font-display swap for Metropolis fonts

### DIFF
--- a/scss/_legacy.scss
+++ b/scss/_legacy.scss
@@ -17526,108 +17526,126 @@ body {
   src: url("/fonts/metropolis/Metropolis-Thin.otf");
   font-weight: 100;
   font-style: normal;
+  font-display: swap;
 }
 @font-face {
   font-family: "Metropolis";
   src: url("/fonts/metropolis/Metropolis-ThinItalic.otf");
   font-weight: 100;
   font-style: italic;
+  font-display: swap;
 }
 @font-face {
   font-family: "Metropolis";
   src: url("/fonts/metropolis/Metropolis-ExtraLight.otf");
   font-weight: 200;
   font-style: normal;
+  font-display: swap;
 }
 @font-face {
   font-family: "Metropolis";
   src: url("/fonts/metropolis/Metropolis-ExtraLightItalic.otf");
   font-weight: 200;
   font-style: italic;
+  font-display: swap;
 }
 @font-face {
   font-family: "Metropolis";
   src: url("/fonts/metropolis/Metropolis-Light.otf");
   font-weight: 300;
   font-style: normal;
+  font-display: swap;
 }
 @font-face {
   font-family: "Metropolis";
   src: url("/fonts/metropolis/Metropolis-LightItalic.otf");
   font-weight: 300;
   font-style: italic;
+  font-display: swap;
 }
 @font-face {
   font-family: "Metropolis";
   src: url("/fonts/metropolis/Metropolis-Regular.otf");
   font-weight: 400;
   font-style: normal;
+  font-display: swap;
 }
 @font-face {
   font-family: "Metropolis";
   src: url("/fonts/metropolis/Metropolis-RegularItalic.otf");
   font-weight: 400;
   font-style: italic;
+  font-display: swap;
 }
 @font-face {
   font-family: "Metropolis";
   src: url("/fonts/metropolis/Metropolis-Medium.otf");
   font-weight: 500;
   font-style: normal;
+  font-display: swap;
 }
 @font-face {
   font-family: "Metropolis";
   src: url("/fonts/metropolis/Metropolis-MediumItalic.otf");
   font-weight: 500;
   font-style: italic;
+  font-display: swap;
 }
 @font-face {
   font-family: "Metropolis";
   src: url("/fonts/metropolis/Metropolis-SemiBold.otf");
   font-weight: 600;
   font-style: normal;
+  font-display: swap;
 }
 @font-face {
   font-family: "Metropolis";
   src: url("/fonts/metropolis/Metropolis-SemiBoldItalic.otf");
   font-weight: 600;
   font-style: italic;
+  font-display: swap;
 }
 @font-face {
   font-family: "Metropolis";
   src: url("/fonts/metropolis/Metropolis-Bold.otf");
   font-weight: 700;
   font-style: normal;
+  font-display: swap;
 }
 @font-face {
   font-family: "Metropolis";
   src: url("/fonts/metropolis/Metropolis-BoldItalic.otf");
   font-weight: 700;
   font-style: italic;
+  font-display: swap;
 }
 @font-face {
   font-family: "Metropolis";
   src: url("/fonts/metropolis/Metropolis-ExtraBold.otf");
   font-weight: 800;
   font-style: normal;
+  font-display: swap;
 }
 @font-face {
   font-family: "Metropolis";
   src: url("/fonts/metropolis/Metropolis-ExtraBoldItalic.otf");
   font-weight: 800;
   font-style: italic;
+  font-display: swap;
 }
 @font-face {
   font-family: "Metropolis";
   src: url("/fonts/metropolis/Metropolis-Black.otf");
   font-weight: 800;
   font-style: normal;
+  font-display: swap;
 }
 @font-face {
   font-family: "Metropolis";
   src: url("/fonts/metropolis/Metropolis-BlackItalic.otf");
   font-weight: 800;
   font-style: italic;
+  font-display: swap;
 }
 #layoutDefault {
   display: -webkit-box;


### PR DESCRIPTION
## Summary
- add `font-display: swap` to Metropolis `@font-face` definitions so text remains visible during font loading

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: interactive ESLint setup prompt)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc3febc9d8833392b2fe6157d9585f