### PR TITLE
Adjust calendar page copy and reusable noindex config

### DIFF
--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -1,0 +1,53 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Schedule a Meeting | Henry Saniuk, Jr.',
+  description: "Reserve time on Henry Saniuk's calendar using the booking tool.",
+  robots: {
+    index: false,
+    follow: false,
+    googleBot: {
+      index: false,
+      follow: false,
+    },
+  },
+  alternates: {
+    canonical: '/calendar',
+  },
+};
+
+export default function CalendarPage() {
+  return (
+    <main>
+      <section className="bg-light py-5">
+        <div className="container">
+          <div className="row justify-content-center mb-4">
+            <div className="col-xl-8 col-lg-9 text-center">
+              <h1 className="mb-3">Schedule time with Henry</h1>
+              <p className="lead mb-0">
+                Choose a meeting slot that works for you using the booking calendar below.
+              </p>
+            </div>
+          </div>
+          <div className="row justify-content-center">
+            <div className="col-xl-10">
+              <div className="card shadow-sm">
+                <div className="card-body p-0">
+                  <iframe
+                    src="https://calendar.google.com/calendar/appointments/schedules/AcZssZ2qh1_kjLlCPrx7du_dZh5qTKgMuN3F2t8TMI9wyKj6Z_ALZffaXAZbYedW5vetD-9ReQc4_qoh?gv=true"
+                    title="Schedule a meeting with Henry Saniuk"
+                    style={{ border: 0 }}
+                    width="100%"
+                    height="600"
+                    frameBorder="0"
+                    loading="lazy"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -53,6 +53,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 
   const canonicalUrl = `https://henrysaniuk.com${pathname === '/' ? '' : pathname.replace(/\/$/, '') + '/'}`;
 
+  const noIndexPrefixes = ['/calendar'];
+  const isIndexablePage = !(pathname && noIndexPrefixes.some((prefix) => pathname.startsWith(prefix)));
+  const robotsContent = isIndexablePage
+    ? 'index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1'
+    : 'noindex, nofollow';
+
   return (
     <html lang="en">
       <head>
@@ -63,9 +69,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <meta name="theme-color" content="#000000" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="author" content="Henry Saniuk, Jr." />
-        <meta name="robots" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1" />
-        <meta name="googlebot" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1" />
-        <meta name="bingbot" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1" />
+        <meta name="robots" content={robotsContent} />
+        <meta name="googlebot" content={robotsContent} />
+        <meta name="bingbot" content={robotsContent} />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
         <Script

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -6,7 +6,7 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: '*',
         allow: '/',
-        disallow: ['/api/', '/_next/'],
+        disallow: ['/api/', '/_next/', '/calendar', '/calendar/'],
       },
     ],
     sitemap: 'https://henrysaniuk.com/sitemap.xml',


### PR DESCRIPTION
## Summary
- update the calendar page copy to reflect the requested wording
- support a reusable list of path prefixes that should emit no-index meta tags in the root layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f979093c9883338c8b87f4a2ee14a4