### PR TITLE
Increase header spacing for resume button

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -7,7 +7,7 @@ export type HeaderProps = {
 
 export default function Header({ brand, resumeLink }: HeaderProps) {
   return (
-    <nav className="navbar navbar-marketing navbar-expand-lg bg-white navbar-light pt-5">
+    <nav className="navbar navbar-marketing navbar-expand-lg bg-white navbar-light pt-5 pb-4">
       <div className="container">
         <Link href="/" className="navbar-brand text-dark">
           {brand}


### PR DESCRIPTION
## Summary
- add extra bottom padding to the global header to keep the resume button away from adjacent sections

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f97edd8b8c8333b191374481062db1