### PR TITLE
Add developer easter egg comment to HTML output

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Script from 'next/script';
 import { usePathname } from 'next/navigation';
 import Header from '../components/Header';
 import Footer from '../components/Footer';
@@ -59,38 +58,40 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     ? 'index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1'
     : 'noindex, nofollow';
 
+  const commentBlock = `<!--
+/*
+   Built by Henry Saniuk
+   Software Engineer | Problem Solver
+
+   If you're reading this, we probably have similar hobbies.
+   Drop me a line: henry@henrysaniuk.com
+*/
+-->`;
+
+  const jsonLdString = JSON.stringify(jsonLd).replace(/</g, '\\u003c');
+
+  const headContent = [
+    commentBlock,
+    '<link rel="icon" href="/img/favicon.png" />',
+    `<link rel="canonical" href="${canonicalUrl}" />`,
+    '<link rel="manifest" href="/manifest.json" />',
+    '<link rel="stylesheet" href="/css/main.min.css" />',
+    '<meta name="theme-color" content="#000000" />',
+    '<meta name="viewport" content="width=device-width, initial-scale=1" />',
+    '<meta name="author" content="Henry Saniuk, Jr." />',
+    `<meta name="robots" content="${robotsContent}" />`,
+    `<meta name="googlebot" content="${robotsContent}" />`,
+    `<meta name="bingbot" content="${robotsContent}" />`,
+    '<link rel="preconnect" href="https://fonts.googleapis.com" />',
+    '<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />',
+    '<script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/js/all.min.js" crossorigin="anonymous" defer></script>',
+    '<script src="https://cdnjs.cloudflare.com/ajax/libs/feather-icons/4.24.1/feather.min.js" crossorigin="anonymous" defer></script>',
+    `<script type="application/ld+json">${jsonLdString}</script>`,
+  ].join('\n');
+
   return (
     <html lang="en">
-      <head>
-        <link rel="icon" href="/img/favicon.png" />
-        <link rel="canonical" href={canonicalUrl} />
-        <link rel="manifest" href="/manifest.json" />
-        <link rel="stylesheet" href="/css/main.min.css" />
-        <meta name="theme-color" content="#000000" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta name="author" content="Henry Saniuk, Jr." />
-        <meta name="robots" content={robotsContent} />
-        <meta name="googlebot" content={robotsContent} />
-        <meta name="bingbot" content={robotsContent} />
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
-        <Script
-          src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/js/all.min.js"
-          crossOrigin="anonymous"
-          strategy="afterInteractive"
-        />
-        <Script
-          src="https://cdnjs.cloudflare.com/ajax/libs/feather-icons/4.24.1/feather.min.js"
-          crossOrigin="anonymous"
-          strategy="afterInteractive"
-        />
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{
-            __html: JSON.stringify(jsonLd),
-          }}
-        />
-      </head>
+      <head dangerouslySetInnerHTML={{ __html: headContent }} />
       <body>
         {pathname !== '/warden' && <CampaignBanner />}
         <Header brand="Henry Saniuk, Jr." resumeLink="/pdf/Henry-Saniuk-Resume.pdf" />


### PR DESCRIPTION
## Summary
- inject a developer easter egg comment at the top of the rendered HTML via the root layout head markup
- preserve existing metadata, canonical link handling, and external script includes while generating the head markup string

## Testing
- npm run lint *(fails: interactive configuration prompt in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fb0ff389488333a52cf9b625c0946f